### PR TITLE
Fix crash caused by now-deprecated UISearchDisplayController.

### DIFF
--- a/Dinesafe.xcodeproj/project.pbxproj
+++ b/Dinesafe.xcodeproj/project.pbxproj
@@ -407,6 +407,7 @@
 					};
 					AD52BF421651E4EF0090723E = {
 						DevelopmentTeam = K6MGT456E4;
+						ProvisioningStyle = Manual;
 						TestTargetID = AD52BF181651E4EF0090723E;
 					};
 				};
@@ -696,13 +697,13 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1.3.2;
+				CURRENT_PROJECT_VERSION = 1.3.3.2;
 				DEVELOPMENT_TEAM = K6MGT456E4;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Dinesafe/Dinesafe-Prefix.pch";
 				INFOPLIST_FILE = "Dinesafe/Dinesafe-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = ca.ruten.dinesafe;
 				PRODUCT_NAME = Dinesafe;
 				PROVISIONING_PROFILE = "";
@@ -721,13 +722,13 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1.3.2;
+				CURRENT_PROJECT_VERSION = 1.3.3.2;
 				DEVELOPMENT_TEAM = K6MGT456E4;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Dinesafe/Dinesafe-Prefix.pch";
 				INFOPLIST_FILE = "Dinesafe/Dinesafe-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = ca.ruten.dinesafe;
 				PRODUCT_NAME = Dinesafe;
 				PROVISIONING_PROFILE = "";
@@ -743,7 +744,10 @@
 			baseConfigurationReference = D569B1196D4E4E09B68EC231 /* Pods-DinesafeTests.debug.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "Apple Development";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = K6MGT456E4;
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
@@ -755,6 +759,8 @@
 				INFOPLIST_FILE = "DinesafeTests/DinesafeTests-Info.plist";
 				PRODUCT_BUNDLE_IDENTIFIER = "ca.ruten.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Dinesafe.app/Dinesafe";
 			};
 			name = Debug;
@@ -764,6 +770,9 @@
 			baseConfigurationReference = D63D802D6390DEF8F679CBE4 /* Pods-DinesafeTests.release.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = K6MGT456E4;
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
@@ -776,6 +785,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ca.ruten.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Dinesafe.app/Dinesafe";
 			};
 			name = Release;
@@ -840,13 +851,13 @@
 				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 1.3.2;
+				CURRENT_PROJECT_VERSION = 1.3.3.2;
 				DEVELOPMENT_TEAM = K6MGT456E4;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Dinesafe/Dinesafe-Prefix.pch";
 				INFOPLIST_FILE = "Dinesafe/Dinesafe-Info.plist";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.3.3;
 				PRODUCT_BUNDLE_IDENTIFIER = ca.ruten.dinesafe;
 				PRODUCT_NAME = Dinesafe;
 				PROVISIONING_PROFILE = "";
@@ -862,6 +873,9 @@
 			baseConfigurationReference = 4B77714A23BD6076043ACA0A /* Pods-DinesafeTests.adhoc.xcconfig */;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "Apple Development";
+				CODE_SIGN_STYLE = Manual;
 				DEVELOPMENT_TEAM = K6MGT456E4;
 				FRAMEWORK_SEARCH_PATHS = (
 					"\"$(SDKROOT)/Developer/Library/Frameworks\"",
@@ -874,6 +888,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "ca.ruten.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE = "";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=macosx*]" = "";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Dinesafe.app/Dinesafe";
 			};
 			name = Adhoc;

--- a/Dinesafe/DSFRootTableViewController.m
+++ b/Dinesafe/DSFRootTableViewController.m
@@ -50,6 +50,7 @@ static CLLocationDegrees const DefaultLocationLng = -79.397238;
 - (void)viewDidLoad
 {
     [super viewDidLoad];
+    
     self.clearsSelectionOnViewWillAppear = NO;
 
     self.currentLocation = nil;

--- a/Dinesafe/Dinesafe-Info.plist
+++ b/Dinesafe/Dinesafe-Info.plist
@@ -49,6 +49,10 @@
 	<array>
 		<string>armv7</string>
 	</array>
+	<key>UIRequiresFullScreen</key>
+	<false/>
+	<key>UIStatusBarHidden</key>
+	<false/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleLightContent</string>
 	<key>UISupportedInterfaceOrientations</key>

--- a/Dinesafe/Launch Screen.xib
+++ b/Dinesafe/Launch Screen.xib
@@ -1,8 +1,10 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="7706" systemVersion="14E46" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina5_9" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="7703"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -13,24 +15,24 @@
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qC1-w2-DH5">
                     <rect key="frame" x="0.0" y="0.0" width="375" height="64"/>
-                    <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="64" id="AjW-0z-ddc"/>
                     </constraints>
                 </view>
                 <tableView clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" style="plain" separatorStyle="default" rowHeight="110" sectionHeaderHeight="22" sectionFooterHeight="22" translatesAutoresizingMaskIntoConstraints="NO" id="vIH-XY-nqs">
                     <rect key="frame" x="0.0" y="108" width="375" height="453"/>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                 </tableView>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="xbk-TP-geJ">
                     <rect key="frame" x="0.0" y="64" width="375" height="43"/>
-                    <color key="backgroundColor" red="0.88430567080624956" green="0.88645121434410334" blue="0.91919191919191923" alpha="1" colorSpace="calibratedRGB"/>
+                    <color key="backgroundColor" red="0.88430567080624956" green="0.88645121434410334" blue="0.91919191919191923" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="43" id="LEb-fr-fx0"/>
                     </constraints>
                 </view>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstItem="xbk-TP-geJ" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="89W-rO-SBS"/>
                 <constraint firstItem="qC1-w2-DH5" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" id="D0u-dz-G6a"/>

--- a/Dinesafe/en.lproj/MainStoryboard_iPhone.storyboard
+++ b/Dinesafe/en.lproj/MainStoryboard_iPhone.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="pn9-Cw-8s6">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment version="1792" identifier="iOS"/>
+        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -48,7 +48,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                        <searchBar key="tableHeaderView" contentMode="redraw" id="TxT-EB-HLP">
+                        <searchBar key="tableHeaderView" contentMode="redraw" text="" id="TxT-EB-HLP">
                             <rect key="frame" x="0.0" y="0.0" width="375" height="56"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMaxY="YES"/>
                             <color key="tintColor" red="0.68000000715255737" green="0.68000000715255737" blue="0.68000000715255737" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -173,34 +173,9 @@
                     <nil key="simulatedStatusBarMetrics"/>
                     <connections>
                         <outlet property="searchBar" destination="TxT-EB-HLP" id="9pr-Jz-rl5"/>
-                        <outlet property="searchDisplayController" destination="eRP-Lg-Ole" id="ewp-U4-LUr"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Zhu-IN-vWj" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <searchDisplayController id="SA8-Lr-0dt">
-                    <connections>
-                        <outlet property="delegate" destination="8RN-zg-ogv" id="Bbr-6W-U1p"/>
-                        <outlet property="searchContentsController" destination="8RN-zg-ogv" id="Y8t-mb-zWv"/>
-                        <outlet property="searchResultsDataSource" destination="8RN-zg-ogv" id="8Ki-wA-YFv"/>
-                        <outlet property="searchResultsDelegate" destination="8RN-zg-ogv" id="pzR-xg-wGr"/>
-                    </connections>
-                </searchDisplayController>
-                <searchDisplayController id="vby-Ac-waN">
-                    <connections>
-                        <outlet property="delegate" destination="8RN-zg-ogv" id="12Y-Ic-uHI"/>
-                        <outlet property="searchContentsController" destination="8RN-zg-ogv" id="Qce-vU-JXX"/>
-                        <outlet property="searchResultsDataSource" destination="8RN-zg-ogv" id="f57-Vk-Mjm"/>
-                        <outlet property="searchResultsDelegate" destination="8RN-zg-ogv" id="SQo-Ap-VVi"/>
-                    </connections>
-                </searchDisplayController>
-                <searchDisplayController id="eRP-Lg-Ole">
-                    <connections>
-                        <outlet property="delegate" destination="8RN-zg-ogv" id="hEa-KY-xBc"/>
-                        <outlet property="searchContentsController" destination="8RN-zg-ogv" id="BAJ-0a-zbv"/>
-                        <outlet property="searchResultsDataSource" destination="8RN-zg-ogv" id="xoS-JP-WQK"/>
-                        <outlet property="searchResultsDelegate" destination="8RN-zg-ogv" id="krP-UQ-VCg"/>
-                    </connections>
-                </searchDisplayController>
             </objects>
             <point key="canvasLocation" x="-800.79999999999995" y="-760.56971514242889"/>
         </scene>
@@ -449,18 +424,9 @@ Minimum Inspections Per Year: 3</string>
                     </navigationItem>
                     <connections>
                         <outlet property="actionButton" destination="hIw-v5-lSh" id="wXb-D5-iAV"/>
-                        <outlet property="searchDisplayController" destination="uqt-pi-ihe" id="h6Q-P6-Nzf"/>
                     </connections>
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="e0j-5B-zwI" userLabel="First Responder" sceneMemberID="firstResponder"/>
-                <searchDisplayController id="uqt-pi-ihe">
-                    <connections>
-                        <outlet property="delegate" destination="mXH-Ey-eCF" id="EVS-Gb-bHC"/>
-                        <outlet property="searchContentsController" destination="mXH-Ey-eCF" id="gdL-JR-vMI"/>
-                        <outlet property="searchResultsDataSource" destination="mXH-Ey-eCF" id="AHC-fK-FtP"/>
-                        <outlet property="searchResultsDelegate" destination="mXH-Ey-eCF" id="gyT-8d-jgT"/>
-                    </connections>
-                </searchDisplayController>
             </objects>
             <point key="canvasLocation" x="858.39999999999998" y="-769.56521739130437"/>
         </scene>


### PR DESCRIPTION
- App works fine when running via XCode, but crashes when distributed.
- Deleted references to this controller from Interface Builder; was not
referenced in code. Seems to work fine still.

Will be released to app store as version `1.3.3`